### PR TITLE
Explicitly use a helper function in first-class-or

### DIFF
--- a/first-class-or/first-class-or.rkt
+++ b/first-class-or/first-class-or.rkt
@@ -1,7 +1,14 @@
-#lang racket/base
+#lang racket
 (provide first-class-or)
 (require (for-syntax racket/base syntax/parse))
 
+(define (or-function . args)
+  (cond [(empty? args)
+         #false]
+        [(first args)] ; answer = question if not false
+        [else
+        (apply or-function (rest args))]))
+        
 (define-syntax (first-class-or stx)
   (syntax-parse stx
    [(_)
@@ -10,12 +17,4 @@
     #'(let ([a-val ?a])
         (if a-val a-val (first-class-or . ?b)))]
    [_:id
-    #'(lambda arg*
-        (let loop ([arg* arg*])
-          (cond
-           [(null? arg*)
-            #false]
-           [(car arg*)
-            (car arg*)]
-           [else
-            (loop (cdr arg*))])))]))
+    #'or-function]))


### PR DESCRIPTION
Suggestion: the inline lambda obscures the logic for beginners. Pull it out into a helper function. I used "full racket" for the helper function, but if you think the primary audience is Scheme users don't do that.
